### PR TITLE
mapped_memory: add [[nodiscard]] to factory methods

### DIFF
--- a/src/patcher/mapped_memory.h
+++ b/src/patcher/mapped_memory.h
@@ -89,13 +89,13 @@ public:
   auto operator=(const MappedMemory &) -> MappedMemory & = delete;
 
   // Factory for read-only mapping
-  static auto open_readonly(const fs::path &path)
+  [[nodiscard]] static auto open_readonly(const fs::path &path)
       -> std::expected<MappedMemory, std::string> {
     return open_impl(path, false);
   }
 
   // Factory for read-write mapping (in-place file modification)
-  static auto open_readwrite(const fs::path &path)
+  [[nodiscard]] static auto open_readwrite(const fs::path &path)
       -> std::expected<MappedMemory, std::string> {
     return open_impl(path, true);
   }


### PR DESCRIPTION

Discarding the result of open_readonly/open_readwrite loses error
information and immediately unmaps the file, which is always a bug.


