### PR TITLE
fix(patcher): fix build without DEFAULT_INTERP, DEFAULT_LIBC_LIB

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,8 @@
                   };
                   test-sanitizers = config.packages.wrapBuddy.passthru.tests.test-sanitizers;
                   test-libcxx = config.packages.wrapBuddy.passthru.tests.test-libcxx;
+                  test-no-default-interp-and-libc =
+                    config.packages.wrapBuddy.passthru.tests.test-no-default-interp-and-libc;
                 }
                 // lib.optionalAttrs pkgs.stdenv.hostPlatform.isx86_64 {
                   test-32bit = pkgs.pkgsi686Linux.callPackage ./nix/package.nix { inherit sources; };

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -11,6 +11,7 @@
   pkgsi686Linux,
   llvmPackages,
   sources,
+  withDefaultInterpAndLibc ? true,
 }:
 
 let
@@ -24,6 +25,11 @@ let
   # - CXX_FOR_BUILD builds wrap-buddy for BUILD platform (what runs the patcher)
   # For native builds, these are the same compiler.
   cxxForBuild = "${buildPackages.stdenv.cc}/bin/c++";
+
+  defaultInterpAndLibcFlags = [
+    "INTERP=${dynamicLinker}"
+    "LIBC_LIB=${libcLib}"
+  ];
 
   # Single derivation builds everything:
   # - loader.bin, stub.bin (and 32-bit variants on x86_64)
@@ -48,13 +54,13 @@ let
       "CXX_FOR_BUILD=${cxxForBuild}"
       "BINDIR=$(out)/bin"
       "LIBDIR=$(out)/lib/wrap-buddy"
-      "INTERP=${dynamicLinker}"
-      "LIBC_LIB=${libcLib}"
     ]
+    ++ lib.optionals withDefaultInterpAndLibc defaultInterpAndLibcFlags
     ++ lib.optional stdenv.hostPlatform.isx86_64 "BUILD_32BIT=1";
 
     nativeInstallCheckInputs = [ strace ];
     doInstallCheck = true;
+    installCheckFlags = defaultInterpAndLibcFlags;
     installCheckTarget = "check";
     enableParallelBuilding = true;
 
@@ -88,6 +94,10 @@ let
         test-sanitizers = wrapBuddy.overrideAttrs (old: {
           EXTRA_CXXFLAGS = "-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all";
         });
+        test-no-default-interp-and-libc = callPackage ./package.nix {
+          withDefaultInterpAndLibc = false;
+          inherit sources;
+        };
         # Build with libc++ to catch libstdc++-specific assumptions
         test-libcxx = (
           llvmPackages.libcxxStdenv.mkDerivation {

--- a/src/patcher/main.cc
+++ b/src/patcher/main.cc
@@ -36,14 +36,14 @@
 #ifdef DEFAULT_INTERP
 constexpr bool kHasDefaultInterp = true;
 #else
-#define DEFAULT_INTERP nullptr
+#define DEFAULT_INTERP ""
 constexpr bool kHasDefaultInterp = false;
 #endif
 
 #ifdef DEFAULT_LIBC_LIB
 constexpr bool kHasDefaultLibcLib = true;
 #else
-#define DEFAULT_LIBC_LIB nullptr
+#define DEFAULT_LIBC_LIB ""
 constexpr bool kHasDefaultLibcLib = false;
 #endif
 


### PR DESCRIPTION
nullptr is not implicitly convertible to std::string and if constexpr with non-dependent names does not prevent the instantiation of the branches that use DEFAULT_INTERP/DEFAULT_LIBC_LIB, so the build would fail.