### PR TITLE
add --needed flag to inject DT_NEEDED entries at runtime

### DIFF
--- a/include/wrap-buddy/config.h
+++ b/include/wrap-buddy/config.h
@@ -31,14 +31,15 @@
  *   [interp_path]   - null-terminated interpreter path
  *   [rpath]         - null-terminated colon-separated library paths
  *   [orig_bytes]    - original bytes from entry point (to restore)
+ *   [needed_names]  - null-separated extra DT_NEEDED sonames (optional)
  *
  * 64-bit header:
- * orig_entry(8) + stub_size(8) + interp_len(2) + rpath_len(2)
- * = 20 bytes
+ * orig_entry(8) + stub_size(8) + interp_len(2) + rpath_len(2) + needed_len(2)
+ * = 22 bytes
  *
  * 32-bit header:
- * orig_entry(4) + stub_size(4) + interp_len(2) + rpath_len(2)
- * = 12 bytes
+ * orig_entry(4) + stub_size(4) + interp_len(2) + rpath_len(2) + needed_len(2)
+ * = 14 bytes
  */
 
 #ifdef __GNUC__
@@ -52,6 +53,8 @@ struct PACKED Config64 {
   uint64_t stub_size;
   uint16_t interp_len;
   uint16_t rpath_len;
+  uint16_t
+      needed_len; /* total bytes of null-separated extra DT_NEEDED sonames */
 };
 
 struct PACKED Config32 {
@@ -59,10 +62,11 @@ struct PACKED Config32 {
   uint32_t stub_size;
   uint16_t interp_len;
   uint16_t rpath_len;
+  uint16_t needed_len;
 };
 
-#define CONFIG64_HEADER_SIZE 20
-#define CONFIG32_HEADER_SIZE 12
+#define CONFIG64_HEADER_SIZE 22
+#define CONFIG32_HEADER_SIZE 14
 
 /*
  * For freestanding code: select config struct based on pointer size

--- a/include/wrap-buddy/elf_defs.h
+++ b/include/wrap-buddy/elf_defs.h
@@ -34,6 +34,7 @@
 
 /* Dynamic section tags (d_tag) */
 #define DT_NULL 0
+#define DT_NEEDED 1
 #define DT_STRTAB 5
 #define DT_RUNPATH 29
 

--- a/nix/wrap-buddy-hook.sh
+++ b/nix/wrap-buddy-hook.sh
@@ -28,6 +28,10 @@ addWrapBuddySearchPath() {
 # Use: runtimeDependencies = [ libsecret ];
 declare -a wrapBuddyRuntimeDeps
 
+# Extra DT_NEEDED sonames to inject at runtime
+# Use: wrapBuddyExtraNeeded = [ "libstdc++.so.6" ];
+declare -a wrapBuddyExtraNeeded
+
 addWrapBuddyRuntimeDeps() {
   local dep
   for dep in "$@"; do
@@ -75,7 +79,8 @@ wrapBuddy() {
     ${norecurse:+--no-recurse} \
     --paths "$@" \
     --libs "${wrapBuddyLibs[@]}" "${extraWrapBuddyLibs[@]}" \
-    ${wrapBuddyRuntimeDeps:+--runtime-dependencies "${wrapBuddyRuntimeDeps[@]}"}
+    ${wrapBuddyRuntimeDeps:+--runtime-dependencies "${wrapBuddyRuntimeDeps[@]}"} \
+    ${wrapBuddyExtraNeeded:+--needed "${wrapBuddyExtraNeeded[@]}"}
 }
 
 # Post-fixup hook to run automatically

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -339,6 +339,19 @@ static size_t count_dyn_entries(ElfW(Dyn) * dyn) {
 }
 
 /*
+ * Count null-terminated strings in a null-separated buffer.
+ */
+static size_t count_needed(const char *buf, size_t len) {
+  size_t count = 0;
+  for (size_t idx = 0; idx < len; idx++) {
+    if (buf[idx] == '\0') {
+      count++;
+    }
+  }
+  return count;
+}
+
+/*
  * Set up RPATH by creating a new .dynamic section with DT_RUNPATH
  *
  * DT_RUNPATH stores an offset from DT_STRTAB, not an absolute address.
@@ -360,7 +373,8 @@ static size_t count_dyn_entries(ElfW(Dyn) * dyn) {
  * ld.so computes: (V + l_addr) + offset = rpath
  */
 static ElfW(Dyn) * setup_rpath(ElfW(Dyn) * orig_dyn, const char *rpath,
-                               uintptr_t l_addr, size_t *out_dyn_count) {
+                               uintptr_t l_addr, size_t *out_dyn_count,
+                               const char *needed_names, size_t needed_len) {
   /* Find DT_STRTAB - we need it to compute the offset */
   ElfW(Dyn) *strtab_entry = find_dyn_entry(orig_dyn, DT_STRTAB);
   if (!strtab_entry) {
@@ -373,7 +387,9 @@ static ElfW(Dyn) * setup_rpath(ElfW(Dyn) * orig_dyn, const char *rpath,
   /* Count original entries and check if DT_RUNPATH exists */
   size_t orig_count = count_dyn_entries(orig_dyn);
   ElfW(Dyn) *runpath_entry = find_dyn_entry(orig_dyn, DT_RUNPATH);
-  size_t new_count = runpath_entry ? orig_count : orig_count + 1;
+  size_t extra_needed =
+      needed_len > 0 ? count_needed(needed_names, needed_len) : 0;
+  size_t new_count = orig_count + (runpath_entry ? 0 : 1) + extra_needed;
 
   /* Allocate memory for new .dynamic section only (rpath is in config mmap) */
   size_t dyn_size = new_count * sizeof(ElfW(Dyn));
@@ -404,11 +420,36 @@ static ElfW(Dyn) * setup_rpath(ElfW(Dyn) * orig_dyn, const char *rpath,
     idx++;
   }
 
-  /* Add DT_NULL terminator */
+  /* Add extra DT_NEEDED entries.
+   * Each soname string lives in the mmap'd config file.  We compute
+   * its offset from DT_STRTAB so ld.so can resolve it.
+   * Iterate with bounded pointer to avoid reading past the buffer. */
+  if (extra_needed > 0) {
+    const char *pos = needed_names;
+    const char *end = needed_names + needed_len;
+    while (pos < end) {
+      /* Compute string length without reading past the buffer */
+      const char *nul = pos;
+      while (nul < end && *nul != '\0') {
+        nul++;
+      }
+      size_t slen = (size_t)(nul - pos);
+      if (slen == 0) {
+        pos++; /* skip empty entries (consecutive nulls) */
+        continue;
+      }
+      new_dyn[idx].d_tag = DT_NEEDED;
+      new_dyn[idx].d_un.d_val = (uintptr_t)pos - strtab_runtime;
+      idx++;
+      pos = nul < end ? nul + 1 : end;
+    }
+  }
+
+  /* idx may be less than new_count if the blob had empty entries */
   new_dyn[idx].d_tag = DT_NULL;
   new_dyn[idx].d_un.d_val = 0;
 
-  *out_dyn_count = new_count;
+  *out_dyn_count = idx + 1;
   return new_dyn;
 }
 
@@ -459,13 +500,14 @@ __attribute__((noreturn)) void loader_main(intptr_t *stack_ptr) {
   /* Validate config field sizes are sane (prevents overflow in sum) */
   // NOLINTNEXTLINE(clang-analyzer-core.UndefinedBinaryOperatorResult)
   if (cfg->interp_len > config_size || cfg->rpath_len > config_size ||
-      cfg->stub_size > config_size) {
+      cfg->stub_size > config_size || cfg->needed_len > config_size) {
     die("config truncated");
   }
 
   /* Now safe to sum - each component <= config_size, no overflow possible */
   size_t expected_size = CONFIG_HEADER_SIZE + (size_t)cfg->interp_len +
-                         (size_t)cfg->rpath_len + (size_t)cfg->stub_size;
+                         (size_t)cfg->rpath_len + (size_t)cfg->stub_size +
+                         (size_t)cfg->needed_len;
   if (expected_size > config_size) {
     die("config truncated");
   }
@@ -475,6 +517,8 @@ __attribute__((noreturn)) void loader_main(intptr_t *stack_ptr) {
   char *interp_path = config_data + CONFIG_HEADER_SIZE;
   char *rpath = interp_path + cfg->interp_len;
   char *orig_bytes = rpath + cfg->rpath_len;
+  char *needed_names = orig_bytes + cfg->stub_size;
+  size_t needed_len = cfg->needed_len;
 
   /* Verify strings are null-terminated (lengths include the null byte) */
   if (cfg->interp_len == 0 || interp_path[cfg->interp_len - 1] != '\0') {
@@ -534,7 +578,8 @@ __attribute__((noreturn)) void loader_main(intptr_t *stack_ptr) {
   }
 
   size_t new_dyn_count;
-  ElfW(Dyn) *new_dyn = setup_rpath(orig_dyn, rpath, l_addr, &new_dyn_count);
+  ElfW(Dyn) *new_dyn = setup_rpath(orig_dyn, rpath, l_addr, &new_dyn_count,
+                                   needed_names, needed_len);
 
   /* Load interpreter */
   void *interp_base = NULL;

--- a/src/patcher/args.h
+++ b/src/patcher/args.h
@@ -24,6 +24,7 @@ struct Args {
   std::vector<fs::path> libs;
   std::vector<fs::path> runtime_deps;
   std::vector<std::string> ignore_missing;
+  std::vector<std::string> needed; // extra DT_NEEDED sonames to inject
   std::optional<std::string> interpreter;
   bool recursive = true;
   bool dry_run = false;
@@ -42,6 +43,8 @@ inline auto usage(std::string_view progname) -> void {
   std::println(
       stderr,
       "                           Patterns for deps to ignore if missing");
+  std::println(stderr,
+               "  --needed SONAME...       Extra DT_NEEDED sonames to inject");
   std::println(stderr,
                "  --no-recurse             Don't recurse into subdirectories");
   std::println(stderr, "  --dry-run                Show what would be done");
@@ -81,6 +84,8 @@ inline auto parse_args(std::span<char *> argv_span)
       collect_args(args.runtime_deps);
     } else if (arg == "--ignore-missing") {
       collect_args(args.ignore_missing);
+    } else if (arg == "--needed") {
+      collect_args(args.needed);
     } else if (arg == "--no-recurse") {
       args.recursive = false;
     } else if (arg == "--dry-run") {

--- a/src/patcher/main.cc
+++ b/src/patcher/main.cc
@@ -121,7 +121,8 @@ auto run_patcher(const Args &args, const InterpreterInfo &interp_info) -> int {
   populate_cache(cache, args.runtime_deps, discovered_lib_dirs, false);
 
   const PatchConfig config{.runtime_deps = args.runtime_deps,
-                           .all_lib_dirs = discovered_lib_dirs};
+                           .all_lib_dirs = discovered_lib_dirs,
+                           .needed = args.needed};
 
   std::vector<MissingDepsError> all_missing;
   std::vector<std::string> errors;

--- a/src/patcher/patcher.h
+++ b/src/patcher/patcher.h
@@ -145,7 +145,9 @@ inline auto write_config_file(const fs::path &config_path, bool is_64bit,
                               uint64_t orig_entry, size_t padded_size,
                               const std::string &interp_path,
                               const std::string &rpath,
-                              std::span<const uint8_t> orig_bytes) -> Result<> {
+                              std::span<const uint8_t> orig_bytes,
+                              const std::vector<std::string> &needed = {})
+    -> Result<> {
   std::ofstream config(config_path, std::ios::binary);
   if (!config) {
     return std::unexpected(std::format(
@@ -156,23 +158,36 @@ inline auto write_config_file(const fs::path &config_path, bool is_64bit,
   auto interp_len = static_cast<uint16_t>(interp_path.size() + 1);
   auto rpath_len = static_cast<uint16_t>(rpath.size() + 1);
 
+  // Build null-separated blob of extra NEEDED sonames
+  std::string needed_blob;
+  for (const auto &name : needed) {
+    needed_blob += name;
+    needed_blob += '\0';
+  }
+  auto needed_len = static_cast<uint16_t>(needed_blob.size());
+
   if (is_64bit) {
     const Config64 hdr{.orig_entry = orig_entry,
                        .stub_size = padded_size,
                        .interp_len = interp_len,
-                       .rpath_len = rpath_len};
+                       .rpath_len = rpath_len,
+                       .needed_len = needed_len};
     write_struct(config, hdr);
   } else {
     const Config32 hdr{.orig_entry = static_cast<uint32_t>(orig_entry),
                        .stub_size = static_cast<uint32_t>(padded_size),
                        .interp_len = interp_len,
-                       .rpath_len = rpath_len};
+                       .rpath_len = rpath_len,
+                       .needed_len = needed_len};
     write_struct(config, hdr);
   }
 
   config.write(interp_path.c_str(), static_cast<std::streamsize>(interp_len));
   config.write(rpath.c_str(), static_cast<std::streamsize>(rpath_len));
   write_bytes(config, orig_bytes);
+  if (!needed_blob.empty()) {
+    config.write(needed_blob.data(), static_cast<std::streamsize>(needed_len));
+  }
 
   std::error_code perm_ec;
   fs::permissions(config_path,
@@ -188,7 +203,9 @@ inline auto write_config_file(const fs::path &config_path, bool is_64bit,
 
 inline auto patch_binary(const fs::path &binary_path,
                          const std::string &interp_path,
-                         const std::string &rpath, bool dry_run) -> Result<> {
+                         const std::string &rpath, bool dry_run,
+                         const std::vector<std::string> &needed = {})
+    -> Result<> {
   // Memory-map file for in-place modification
   auto mem_result = MappedMemory::open_readwrite(binary_path);
   if (!mem_result) {
@@ -277,8 +294,9 @@ inline auto patch_binary(const fs::path &binary_path,
   auto config_path = binary_path.parent_path() /
                      ("." + binary_path.filename().string() + ".wrapbuddy");
 
-  if (auto err = write_config_file(config_path, is_64bit, orig_entry,
-                                   padded_size, interp_path, rpath, orig_bytes);
+  if (auto err =
+          write_config_file(config_path, is_64bit, orig_entry, padded_size,
+                            interp_path, rpath, orig_bytes, needed);
       !err) {
     return std::unexpected(err.error());
   }

--- a/src/patcher/resolver.h
+++ b/src/patcher/resolver.h
@@ -33,6 +33,7 @@ struct InterpreterInfo {
 struct PatchConfig {
   std::vector<fs::path> runtime_deps;
   std::set<fs::path> all_lib_dirs;
+  std::vector<std::string> needed; // extra DT_NEEDED sonames
 };
 
 // Result types for explicit control flow
@@ -186,8 +187,8 @@ inline auto process_binary(const fs::path &binary_path,
 
   std::println("Patching: {}", binary_path.string());
 
-  auto patch_result =
-      patch_binary(binary_path, interp_info.path, rpath, dry_run);
+  auto patch_result = patch_binary(binary_path, interp_info.path, rpath,
+                                   dry_run, config.needed);
   if (!patch_result) {
     return std::unexpected(ProcessError{patch_result.error()});
   }

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Test script for wrap-buddy
-# Usage: ./test.sh --interp PATH --libs PATH
+# Integration tests for wrap-buddy
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WRAP_BUDDY="$SCRIPT_DIR/../wrap-buddy"
 INTERP=""
 LIBS=""
 
@@ -28,7 +28,6 @@ done
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
-# Detect FHS interpreter for this architecture
 ARCH=$(uname -m)
 case $ARCH in
 x86_64) FHS_INTERP="/lib64/ld-linux-x86-64.so.2" ;;
@@ -40,26 +39,43 @@ aarch64) FHS_INTERP="/lib/ld-linux-aarch64.so.1" ;;
   ;;
 esac
 
-echo "=== Building test binary with FHS interpreter ${FHS_INTERP} ==="
-${CC:-cc} -o "$TMPDIR/test" "$SCRIPT_DIR/test_program.c" \
-  -Wl,--dynamic-linker="$FHS_INTERP"
+compile() {
+  ${CC:-cc} -o "$TMPDIR/$1" "$SCRIPT_DIR/$2" \
+    -Wl,--dynamic-linker="$FHS_INTERP" "${@:3}"
+}
 
-echo "=== Patching with wrap-buddy ==="
-"$SCRIPT_DIR/../wrap-buddy" --paths "$TMPDIR/test" --interpreter "$INTERP" --libs "$LIBS"
-
-echo "=== Config file contents ==="
-xxd "$TMPDIR/.test.wrapbuddy"
-
-echo "=== strace output ==="
-strace -f "$TMPDIR/test" 2>&1 || true
-
-echo "=== Running patched binary ==="
-output=$("$TMPDIR/test" 2>&1)
-echo "$output"
-
-if ! echo "$output" | grep -q "Hello from patched binary!"; then
-  echo "ERROR: expected output not found"
+pass() { echo "PASS: $1"; }
+fail() {
+  echo "FAIL: $1"
   exit 1
-fi
+}
 
-echo "=== Test passed ==="
+# --- Test 1: basic patching -------------------------------------------
+
+echo "=== Test: basic patching ==="
+compile basic test_program.c
+
+"$WRAP_BUDDY" --paths "$TMPDIR/basic" --interpreter "$INTERP" --libs "$LIBS"
+
+output=$("$TMPDIR/basic" 2>&1)
+echo "$output" | grep -q "Hello from patched binary!" ||
+  fail "patched binary did not produce expected output"
+pass "basic patching"
+
+# --- Test 2: --needed injects DT_NEEDED at runtime --------------------
+
+echo "=== Test: --needed injection ==="
+${CC:-cc} -shared -fPIC -o "$TMPDIR/libneeded_test.so" \
+  "$SCRIPT_DIR/test_needed_lib.c"
+
+compile check test_needed_program.c
+
+"$WRAP_BUDDY" --paths "$TMPDIR/check" --interpreter "$INTERP" \
+  --libs "$LIBS" "$TMPDIR" --needed libneeded_test.so
+
+output=$("$TMPDIR/check" 2>&1)
+echo "$output" | grep -q "NEEDED_LOADED=yes" ||
+  fail "injected DT_NEEDED library was not loaded"
+pass "--needed injection"
+
+echo "=== All tests passed ==="

--- a/tests/test_needed_lib.c
+++ b/tests/test_needed_lib.c
@@ -1,0 +1,9 @@
+/*
+ * Shared library for testing --needed injection.
+ * A constructor sets an env var so the test binary can verify it was loaded.
+ */
+#include <stdlib.h>
+
+__attribute__((constructor)) static void needed_lib_init(void) {
+  setenv("WRAPBUDDY_NEEDED_LOADED", "1", 1);
+}

--- a/tests/test_needed_program.c
+++ b/tests/test_needed_program.c
@@ -1,0 +1,20 @@
+/*
+ * Test program for --needed injection.
+ * Does NOT link libneeded_test.so — wrap-buddy injects it at runtime.
+ * Prints whether the library's constructor ran.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void) {
+  const char *val = getenv("WRAPBUDDY_NEEDED_LOADED");
+  printf("NEEDED_LOADED=%s\n", (val && val[0] == '1') ? "yes" : "no");
+  return (val && val[0] == '1') ? 0 : 1;
+}
+
+/* Reserve space at entry point for the stub */
+#if defined(__x86_64__) || defined(__i386__)
+__asm__(".section .text\n.space 4096, 0x90\n");
+#elif defined(__aarch64__)
+__asm__(".section .text\n.space 4096, 0x1f\n");
+#endif


### PR DESCRIPTION
Some binaries dlopen plugins or native addons that require libraries
the main executable does not link. `patchelf --add-needed` can add
them, but it resizes the ELF which breaks binaries with appended
payloads.

Inject `DT_NEEDED` entries into the `.dynamic` section the loader
already creates at runtime. ld.so loads the specified libraries at
process start without modifying the binary on disk.

### Nix hook

```nix
wrapBuddyExtraNeeded = [ "libstdc++.so.6" ];
```

### CLI

```bash
wrap-buddy --paths ./bin --needed libstdc++.so.6 --libs /path/to/lib
```