### PR TITLE
chore: only consider wrap-buddy at the repo root in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.o
 *.elf
 *.bin
-wrap-buddy
+/wrap-buddy
 compile_commands.json
 
 # Generated stub headers


### PR DESCRIPTION
Without this editors that take .gitignore into account (like helix) don't list files under include/wrap-buddy. Modify the gitignore to only include the path at the repository root.