### PR TITLE
Use $ORIGIN and relative paths in build_rpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Options:
   --no-recurse                 Don't recurse into subdirectories
   --dry-run                    Show what would be done
   --interpreter PATH           Path to dynamic linker
+  --relative-rpath             Construct RUNPATH with $ORIGIN and relative paths for dependencies
   --help                       Show help
 ```
 

--- a/src/patcher/args.h
+++ b/src/patcher/args.h
@@ -28,6 +28,7 @@ struct Args {
   std::optional<std::string> interpreter;
   bool recursive = true;
   bool dry_run = false;
+  bool relative_rpath = false;
 };
 
 inline auto usage(std::string_view progname) -> void {
@@ -49,6 +50,8 @@ inline auto usage(std::string_view progname) -> void {
                "  --no-recurse             Don't recurse into subdirectories");
   std::println(stderr, "  --dry-run                Show what would be done");
   std::println(stderr, "  --interpreter PATH       Path to dynamic linker");
+  std::println(stderr, "  --relative-rpath         Construct RUNPATH with "
+                       "$ORIGIN and relative paths for dependencies");
   std::println(stderr, "  --help                   Show this help");
 }
 
@@ -90,6 +93,8 @@ inline auto parse_args(std::span<char *> argv_span)
       args.recursive = false;
     } else if (arg == "--dry-run") {
       args.dry_run = true;
+    } else if (arg == "--relative-rpath") {
+      args.relative_rpath = true;
     } else if (arg == "--interpreter") {
       if (idx >= argv_span.size()) {
         return std::unexpected(

--- a/src/patcher/main.cc
+++ b/src/patcher/main.cc
@@ -120,9 +120,12 @@ auto run_patcher(const Args &args, const InterpreterInfo &interp_info) -> int {
   populate_cache(cache, args.libs, discovered_lib_dirs, false);
   populate_cache(cache, args.runtime_deps, discovered_lib_dirs, false);
 
-  const PatchConfig config{.runtime_deps = args.runtime_deps,
-                           .all_lib_dirs = discovered_lib_dirs,
-                           .needed = args.needed};
+  const PatchConfig config{
+      .runtime_deps = args.runtime_deps,
+      .all_lib_dirs = discovered_lib_dirs,
+      .needed = args.needed,
+      .relative_rpath = args.relative_rpath,
+  };
 
   std::vector<MissingDepsError> all_missing;
   std::vector<std::string> errors;

--- a/src/patcher/resolver.h
+++ b/src/patcher/resolver.h
@@ -34,6 +34,7 @@ struct PatchConfig {
   std::vector<fs::path> runtime_deps;
   std::set<fs::path> all_lib_dirs;
   std::vector<std::string> needed; // extra DT_NEEDED sonames
+  bool relative_rpath; // Use $ORIGIN and relative paths when building the rpath
 };
 
 // Result types for explicit control flow
@@ -68,12 +69,13 @@ inline auto resolve_dependency(const std::string &dep, const SonameCache &cache,
   return find_dependency(cache, dep, arch, osabi);
 }
 
-inline auto build_rpath(const std::set<fs::path> &library_dirs,
+inline auto build_rpath(const fs::path &binary_dir,
+                        const std::set<fs::path> &library_dirs,
                         const std::vector<fs::path> &runtime_deps,
                         const std::set<fs::path> &all_lib_dirs,
                         const std::optional<fs::path> &libc_lib,
-                        const std::vector<std::string> &existing_rpath)
-    -> std::string {
+                        const std::vector<std::string> &existing_rpath,
+                        bool relative_rpath) -> std::string {
   std::set<fs::path> combined = all_lib_dirs;
   combined.insert(library_dirs.begin(), library_dirs.end());
   std::error_code err_code;
@@ -94,18 +96,25 @@ inline auto build_rpath(const std::set<fs::path> &library_dirs,
   }
 
   std::string result;
-  for (const auto &dir : combined) {
+
+  auto append_path_entry = [&](const fs::path &p) {
     if (!result.empty()) {
       result += ':';
     }
-    result += dir.string();
+    if (relative_rpath) {
+      result += "$ORIGIN/";
+      result += fs::relative(p, binary_dir).string();
+    } else {
+      result += p.string();
+    }
+  };
+
+  for (const auto &dir : combined) {
+    append_path_entry(dir);
   }
 
   if (libc_lib) {
-    if (!result.empty()) {
-      result += ':';
-    }
-    result += libc_lib->string();
+    append_path_entry(*libc_lib);
   }
 
   return result;
@@ -181,9 +190,9 @@ inline auto process_binary(const fs::path &binary_path,
         MissingDepsError{.binary = binary_path, .deps = std::move(missing)}});
   }
 
-  auto rpath =
-      build_rpath(library_dirs, config.runtime_deps, config.all_lib_dirs,
-                  interp_info.libc_lib, existing_rpath);
+  auto rpath = build_rpath(binary_dir, library_dirs, config.runtime_deps,
+                           config.all_lib_dirs, interp_info.libc_lib,
+                           existing_rpath, config.relative_rpath);
 
   std::println("Patching: {}", binary_path.string());
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -78,4 +78,17 @@ echo "$output" | grep -q "NEEDED_LOADED=yes" ||
   fail "injected DT_NEEDED library was not loaded"
 pass "--needed injection"
 
+# --- Test 3: --relative-rpath patching --------------------------------
+
+echo "=== Test: --relative-rpath ==="
+
+compile relative_rpath test_program.c
+
+"$WRAP_BUDDY" --paths "$TMPDIR/relative_rpath" --interpreter "$INTERP" --libs "$LIBS" --relative-rpath
+
+output=$("$TMPDIR/relative_rpath" 2>&1)
+echo "$output" | grep -q "Hello from patched binary!" ||
+  fail "patched binary did not produce expected output"
+pass "--relative-rpath patching"
+
 echo "=== All tests passed ==="


### PR DESCRIPTION
Easy things to help with relocatability of store objects [1]. I have a patch locally to allow looking up the dynamic linker and loader.bin via relative paths too, but that's a bigger change. A pretty common pain point with nix is hardcoded absolute paths for RUNPATH dependencies, which make it much harder to produce relocatable binaries (those that can be copied anywhere while preserving their relative paths). A typical use-case for this is patchelf-ing Nix-built binaries to "smuggle" those out onto other distros / systems without a nix store.

This is of course an incomplete solution (for now), but follow up patches will introduce a "RELOCATABLE" mode, wherein the stub looks up the `loader.bin` with path relative to the executable directory. The same can be accomplished for the interpreter resolution in the loader.bin second-stage loader.

[1]: https://github.com/NixOS/nix/issues/9549