### PR TITLE
Add 'nix bundle' support for relocatable bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,18 @@ Caveats:
 - The relative path from the binary to `loader.bin` can be at most 128
   characters.
 
+### nix bundle
+
+The flake also provides a bundler that turns a Nix package into such a tree:
+executables in `bin/`, the dynamic linker and all runtime libraries in `lib/`,
+patched with `--relocatable`. The result runs on any Linux without `/nix/store`:
+
+```bash
+nix bundle --bundler github:Mic92/wrap-buddy nixpkgs#hello
+tar czhf hello.tar.gz -C hello-bundle .
+# unpack on the target system and run bin/hello
+```
+
 ## Requirements
 
 The binary must have sufficient space at the entry point for the stub (~400 bytes).

--- a/flake.nix
+++ b/flake.nix
@@ -23,11 +23,20 @@
         inputs.treefmt-nix.flakeModule
       ];
 
+      # 'nix bundle --bundler <this flake> <package>' produces a relocatable bin/ + lib/ tree
+      flake.bundlers = inputs.nixpkgs.lib.genAttrs [ "x86_64-linux" "aarch64-linux" ] (system: rec {
+        default = wrapBuddy;
+        wrapBuddy = inputs.nixpkgs.legacyPackages.${system}.callPackage ./nix/bundler.nix {
+          wrapBuddy = inputs.self.packages.${system}.wrapBuddy.passthru.wrapBuddy;
+        };
+      });
+
       perSystem =
         {
           config,
           pkgs,
           lib,
+          system,
           ...
         }:
         let
@@ -61,6 +70,15 @@
                   test-libcxx = config.packages.wrapBuddy.passthru.tests.test-libcxx;
                   test-no-default-interp-and-libc =
                     config.packages.wrapBuddy.passthru.tests.test-no-default-interp-and-libc;
+                  bundle-hello = pkgs.runCommand "bundle-hello-test" { } ''
+                    # Run from a copied tree to make sure nothing refers to the bundle's store path
+                    cp -r ${inputs.self.bundlers.${system}.default pkgs.hello} tree
+                    chmod -R u+w tree
+                    ./tree/bin/hello | grep -q "Hello, world!"
+                    test -e tree/lib/loader.bin
+                    test -e tree/bin/.hello.wrapbuddy
+                    touch $out
+                  '';
                 }
                 // lib.optionalAttrs pkgs.stdenv.hostPlatform.isx86_64 {
                   test-32bit = pkgs.pkgsi686Linux.callPackage ./nix/package.nix { inherit sources; };

--- a/nix/bundler.nix
+++ b/nix/bundler.nix
@@ -1,0 +1,47 @@
+# Bundler for 'nix bundle': turns a Nix package into a relocatable tree
+# (bin/ + lib/) that runs on any Linux without /nix/store.
+{
+  runCommand,
+  closureInfo,
+  wrapBuddy,
+}:
+drv:
+runCommand "${drv.pname or drv.name}-bundle"
+  {
+    nativeBuildInputs = [ wrapBuddy ];
+    closure = closureInfo { rootPaths = [ drv ]; };
+  }
+  ''
+    mkdir -p $out/bin $out/lib
+
+    # Copy executables
+    for f in ${drv}/bin/*; do
+      [ -f "$f" ] || continue
+      cp -L "$f" $out/bin/
+    done
+
+    # Copy shared libraries and the dynamic linker from the runtime closure
+    while read -r path; do
+      for so in "$path"/lib/*.so*; do
+        [ -e "$so" ] || continue
+        cp -Ln "$so" $out/lib/
+      done
+    done < $closure/store-paths
+
+    chmod -R u+w $out
+
+    interp=$(find $out/lib -maxdepth 1 -name 'ld-*.so.*' | head -n1)
+    if [ -z "$interp" ]; then
+      echo "no dynamic linker found in closure of ${drv}" >&2
+      exit 1
+    fi
+
+    cp ${wrapBuddy}/lib/wrap-buddy/loader.bin $out/lib/
+
+    wrap-buddy \
+      --paths $out/bin \
+      --libs $out/lib \
+      --interpreter "$interp" \
+      --relocatable \
+      --loader-dir-path $out/lib
+  ''

--- a/src/patcher/resolver.h
+++ b/src/patcher/resolver.h
@@ -146,9 +146,11 @@ inline auto process_binary(const fs::path &binary_path,
     return PatchResult::Skipped;
   }
 
-  // Skip if already has Nix store interpreter
+  // Skip if already has Nix store interpreter, except in relocatable mode
+  // where Nix-built binaries are bundled for use outside the store.
   auto current_interp = elf.interpreter();
-  if (current_interp && current_interp->starts_with("/nix/store/")) {
+  if (!config.relocatable && current_interp &&
+      current_interp->starts_with("/nix/store/")) {
     return PatchResult::Skipped;
   }
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -112,4 +112,24 @@ echo "$output" | grep -q "Hello from patched binary!" ||
   fail "patched binary did not work after move"
 pass "--relocatable binary movement"
 
+# --- Test 5: --relocatable patches binaries with target interpreter ---
+# Needed for 'nix bundle': Nix-built binaries already point at the target
+# interpreter but still have to be patched.
+
+echo "=== Test: --relocatable with target interpreter ==="
+
+${CC:-cc} -o "$TMPDIR/nix_built" "$SCRIPT_DIR/test_program.c" \
+  -Wl,--dynamic-linker="$INTERP"
+
+patch_output=$("$WRAP_BUDDY" --paths "$TMPDIR/nix_built" --interpreter "$INTERP" \
+  --libs "$LIBS" --relocatable)
+
+echo "$patch_output" | grep -q "Patching: $TMPDIR/nix_built" ||
+  fail "binary with target interpreter was not patched in relocatable mode"
+
+output=$("$TMPDIR/nix_built" 2>&1)
+echo "$output" | grep -q "Hello from patched binary!" ||
+  fail "patched binary did not produce expected output"
+pass "--relocatable with target interpreter"
+
 echo "=== All tests passed ==="


### PR DESCRIPTION
Adds a `bundlers` flake output:

```
nix bundle --bundler github:Mic92/wrap-buddy nixpkgs#hello
```

This produces a relocatable bin/ + lib/ tree (executables, runtime libraries, ld.so, loader.bin) patched with `--relocatable`, which runs on any Linux without /nix/store.

This only works for library dependencies. What I am not so sure yet about is what to do with other type of /nix/store references...