### PR TITLE
nfc: expose wrap-buddy CLI via nix build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
           packages = lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
             default = config.packages.wrapBuddy;
             wrapBuddy = pkgs.callPackage ./nix/package.nix { inherit sources; };
+            wrapBuddy-unwrapped = config.packages.wrapBuddy.wrapBuddy;
           };
 
           checks =


### PR DESCRIPTION
Add wrapBuddy-unwrapped package which is the underlying tool. Useful so we can `nix build` it to run through the examples ourselves.