### PR TITLE
Build the stub with -Oz instead of -Os

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ endif
 # Freestanding flags - no libc, no system headers
 CFLAGS_BASE = -Wall -nostdlib -nostdinc -fPIC -fno-stack-protector \
               -fno-exceptions -fno-unwind-tables \
-              -fno-asynchronous-unwind-tables -fno-builtin -Os -Iinclude
+              -fno-asynchronous-unwind-tables -fno-builtin -Oz -Iinclude
 
 # Linker flags for flat binary output
 LDFLAGS = -Wl,-T,src/preamble.ld -Wl,-e,_start -Wl,-Ttext=0


### PR DESCRIPTION
This cuts down the binary size for 64 bit builds quite a bit (407 -> 375 bytes on 64 bit x86_64-linux). With some more improvements it can be reduced even further.

Unlike -Os, -Oz prioritises the binary size above all else and uses slightly better codegen for loading immediate values (push + pop from the stack - 3 bytes instead of mov which is 5 bytes on x86_64).